### PR TITLE
Adds option to place 'note' area in gmail sidebar

### DIFF
--- a/common/content-common.js
+++ b/common/content-common.js
@@ -651,7 +651,14 @@ setupListeners = function(){
           debugLog("@485, move to bottom");
           //$(".nH.aHU").find(".sgn_container").remove();
           $(".nH.aHU").append(firstVisible);
+        } else if(notePosition == "side-top") {
+          $(".nH.adC").prepend(firstVisible);
+        } else if(notePosition == "side-bottom") {
+          $(".nH.adC").append(firstVisible);
         }
+
+        //reset class attribute with current 'position' class
+        firstVisible.attr('class', 'sgn_container sgn_position_' + notePosition);
 
         var showConnectionPrompt = (preferences["showConnectionPrompt"] !== "false");
         if(!showConnectionPrompt){

--- a/common/content-common.js
+++ b/common/content-common.js
@@ -654,7 +654,7 @@ setupListeners = function(){
         } else if(notePosition == "side-top") {
           $(".nH.adC").prepend(firstVisible);
         } else if(notePosition == "side-bottom") {
-          $(".nH.adC").append(firstVisible);
+          $(".nH.adC .nH .u5").before(firstVisible);
         }
 
         //reset class attribute with current 'position' class

--- a/css/style.css
+++ b/css/style.css
@@ -6,6 +6,12 @@
 
 }
 
+.sgn_container.sgn_position_side-top,
+.sgn_container.sgn_position_side-bottom {
+  margin-left: 0;
+  margin-right: 0;
+}
+
 .sgn_container .sgn_action,
 .sgn_container .sgn_prompt_logout,
 .sgn_container .sgn_prompt_login {
@@ -32,6 +38,12 @@
   height: 72px;
   color: gray;
   margin: 5px;
+  box-sizing: border-box;
+}
+
+.sgn_container.sgn_position_side-top textarea.sgn_input,
+.sgn_container.sgn_position_side-bottom textarea.sgn_input {
+  margin: 5px 0;
 }
 
 .sgn_search img {

--- a/options.html
+++ b/options.html
@@ -52,6 +52,8 @@
         <select id="note_position">
           <option>top</option>
           <option>bottom</option>
+          <option value="side-top">sidebar top</option>
+          <option value="side-bottom">sidebar bottom</option>
         </select>
       </td>
     </tr>


### PR DESCRIPTION
First of all, awesome plugin - thanks!

This PR allows you to put the "note area" in the gmail sidebar, which tends to have a lot more free space.
